### PR TITLE
feat: 이미지 해상도 개선

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -253,3 +253,12 @@ input[type='number'] {
   display: inline-block;
   animation: popUpDown 1s ease-in-out infinite;
 }
+
+/* 이미지 확대 시 픽셀 모양 유지 */
+.zoom-preview-img {
+  /* 기본값, 브라우저가 최적화  */
+  image-rendering: auto;
+
+  /* 픽셀을 또렷하게 */
+  /* image-rendering: crisp-edges; */
+}

--- a/src/components/product/ZoomPreview.tsx
+++ b/src/components/product/ZoomPreview.tsx
@@ -44,7 +44,6 @@ export const ZoomPreview = ({
         alt='확대 이미지'
         fill
         quality={100}
-        // className='object-cover pointer-events-none'
         className='object-cover pointer-events-none zoom-preview-img'
         style={{
           transform: `translate(-${offsetX}px, -${offsetY}px) scale(${scale})`,

--- a/src/components/product/ZoomPreview.tsx
+++ b/src/components/product/ZoomPreview.tsx
@@ -43,7 +43,9 @@ export const ZoomPreview = ({
         src={src}
         alt='확대 이미지'
         fill
-        className='object-cover pointer-events-none'
+        quality={100}
+        // className='object-cover pointer-events-none'
+        className='object-cover pointer-events-none zoom-preview-img'
         style={{
           transform: `translate(-${offsetX}px, -${offsetY}px) scale(${scale})`,
           transformOrigin: 'top left',


### PR DESCRIPTION
제품 확대 이미지 해상도 개선 시도
- 이미지를 최대 품질로 렌더링 할 수 있도록 설정 (`quality={100}` 속성 추가)
- CSS 이미지-렌더링 속성 적용 (`image-rendering: auto;`)

근본적인 원인을 해결하지는 못함
- DB에 저장된 원본 이미지가 크고 해상도가 높아야 됨